### PR TITLE
ui-sortable options for array decorator

### DIFF
--- a/src/array.html
+++ b/src/array.html
@@ -2,7 +2,7 @@
       sf-field-model="sf-new-array"
       sf-new-array>
   <label class="control-label" ng-show="showTitle()">{{ form.title }}</label>
-  <ol class="list-group" ui-sortable>
+  <ol class="list-group" ui-sortable="{{form.sortOptions}}">
     <li class="list-group-item {{form.fieldHtmlClass}}"
         schema-form-array-items
         sf-field-model="ng-repeat"


### PR DESCRIPTION
This (tiny) change allows ui-sortable options to be passed into the directive via an optional sortOptions key on the form.

e.g. adding 
```javascript
"sortOptions": "{'cancel': 'ol'}" 
```
will disable sorting. This is particularly useful if you want certain arrays to be sortable but not all of them. It also opens up the ability to make use of all of the possible options listed [here](http://api.jqueryui.com/sortable/).