### PR TITLE
Put ng-if on the correct items in a formSelect

### DIFF
--- a/examples/data/anyof.json
+++ b/examples/data/anyof.json
@@ -23,7 +23,10 @@
             { "type" : "object", "properties" : { "price" : { "type" : "number" } } }
           ]
         }
-      }
+      },
+      "a": {"type": "number"},
+      "b": {"type": "string"},
+      "c": {"type": "integer"}
     },
     "required": ["name","email","comment"]
   },
@@ -41,9 +44,25 @@
     },
     "subforms",
     {
+      "type": "formselect",
+      "title": "manually configured (no oneOf)",
+      "titleMap": [
+        {"name": "a and b", "value": 0},
+        {"name": "c", "value": 1}
+      ],
+      "items": [
+        {"type": "fieldset", "items": ["a", "b"]},
+        "c"
+      ]
+    },
+    {
       "type": "submit",
 	  "style": "btn-info",
       "title": "OK"
     }
-  ]
+  ],
+  "model": {
+    "name": 7,
+    "subforms": [{}]
+  }
 }

--- a/examples/data/anyof.json
+++ b/examples/data/anyof.json
@@ -51,7 +51,7 @@
         {"name": "c", "value": 1}
       ],
       "items": [
-        {"type": "fieldset", "items": ["a", "b"]},
+        ["a", "b"],
         "c"
       ]
     },

--- a/src/bootstrap-decorator.js
+++ b/src/bootstrap-decorator.js
@@ -30,7 +30,7 @@ function(decoratorsProvider, sfBuilderProvider, sfPathProvider) {
   };
 
   var formSelectItemsNgShow = function(args) {
-    var children = args.fieldFrag.querySelectorAll('[sf-field-transclude] [sf-field]');
+    var children = args.fieldFrag.querySelectorAll('[sf-field-transclude] .form-group');
 
     for (var i = 0; i < children.length; i++) {
       children[i].setAttribute('ng-if', 'selectedForm.value === ' + i);

--- a/src/bootstrap-decorator.js
+++ b/src/bootstrap-decorator.js
@@ -39,7 +39,7 @@ function(decoratorsProvider, sfBuilderProvider, sfPathProvider) {
 
   var defaults = [sfField, ngModel, ngModelOptions, condition];
   decoratorsProvider.defineDecorator('bootstrapDecorator', {
-    formselect: {template: base + 'formselect.html', builder: [sfField, transclusion, formSelectItemsNgShow, condition, ngModelOptions, ngModel]},
+    formselect: {template: base + 'formselect.html', builder: [sfField, transclusion, formSelectItemsNgShow, condition, ngModelOptions]},
     textarea: {template: base + 'textarea.html', builder: defaults},
     fieldset: {template: base + 'fieldset.html', builder: [sfField, simpleTransclusion, condition]},
     array: {template: base + 'array.html', builder: [sfField, ngModelOptions, ngModel, array, condition]},

--- a/src/bootstrap-decorator.js
+++ b/src/bootstrap-decorator.js
@@ -30,7 +30,7 @@ function(decoratorsProvider, sfBuilderProvider, sfPathProvider) {
   };
 
   var formSelectItemsNgShow = function(args) {
-    var children = args.fieldFrag.querySelectorAll('[sf-field-transclude] .form-group');
+    var children = args.fieldFrag.querySelectorAll('[sf-field-transclude] > *');
 
     for (var i = 0; i < children.length; i++) {
       children[i].setAttribute('ng-if', 'selectedForm.value === ' + i);

--- a/src/formselect.html
+++ b/src/formselect.html
@@ -1,5 +1,4 @@
 <div class="schema-form-form-select {{form.htmlClass}}" sf-form-select="form">
-  <h1>Form select</h1>
   <legend ng-class="{'sr-only': !showTitle() }">{{ form.title }}</legend>
   <div class="help-block" ng-show="form.description" ng-bind-html="form.description"></div>
   <select ng-model="selectedForm.value"


### PR DESCRIPTION
The builder function to grab the subforms for a formselect wasn't selecting the right things. (that's why the array example was broken.) This fix works for the current example form, I'm not positive if it's _right_ though.